### PR TITLE
Use K8s external-dns deployment to mange DigitalOcean DNS

### DIFF
--- a/digitalocean/k8s-cluster.tf
+++ b/digitalocean/k8s-cluster.tf
@@ -1,7 +1,7 @@
 resource "digitalocean_kubernetes_cluster" "k8s" {
     name    = "c5r"
     region  = "sfo2"
-    version = "1.13.1-do.f.3"
+    version = "1.13.5-do.f.0"
 
     node_pool {
         name        = "workers"

--- a/digitalocean/sbtechcoop-domain.tf
+++ b/digitalocean/sbtechcoop-domain.tf
@@ -1,26 +1,3 @@
-data "digitalocean_loadbalancer" "sbtechcoop" {
-    name = "ingress"
-}
-
 resource "digitalocean_domain" "sbtechcoop" {
     name = "sbtechcoop.com"
 }
-
-resource "digitalocean_record" "domain" {
-    domain  = "${digitalocean_domain.sbtechcoop.name}"
-    type    = "A"
-    name    = "@"
-    value   = "${data.digitalocean_loadbalancer.sbtechcoop.ip}"
-    ttl     = 300
-}
-
-resource "digitalocean_record" "www" {
-    domain  = "${digitalocean_domain.sbtechcoop.name}"
-    type    = "CNAME"
-    name    = "www"
-    value   = "sbtechcoop.com."
-    ttl     = 300
-}
-
-output "domain-fqdn"    { value = "${digitalocean_record.domain.fqdn}" }
-output "www-fqdn"       { value = "${digitalocean_record.www.fqdn}" }

--- a/kubernetes/digitalocean/external-dns.yaml
+++ b/kubernetes/digitalocean/external-dns.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get","watch","list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get","watch","list"]
+- apiGroups: ["extensions"]
+  resources: ["ingresses"]
+  verbs: ["get","watch","list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+  namespace: default
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: external-dns-do-token
+type: Opaque
+data:
+  do_token: ""
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: external-dns
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      serviceAccountName: external-dns
+      containers:
+      - name: external-dns
+        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        args:
+        - --source=ingress
+        - --provider=digitalocean
+        env:
+        - name: DO_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: external-dns-do-token
+              key: do_token


### PR DESCRIPTION
Previously using Terraform left the implementation vulnerable to service outages when the loadbalancer was destroyed and recreated (this seems to happen when DO goes through Kubernetes maintenance).

Using `external-dns` keeps the K8s provisioned loadbalancer in-line with the DNS that's routing to it at all times.